### PR TITLE
Handle exceptions in promisify function

### DIFF
--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -13,7 +13,7 @@ exports.start = function start () {
     ].join(""));
 };
 
-exports.end = function start () {
+exports.end = function end () {
     this.end = new Date();
     util.log([
         "Finished '",
@@ -21,5 +21,14 @@ exports.end = function start () {
         "' after ",
         util.colors.magenta(execTimeString(this.end - this.start)),
         "s"
+    ].join(""));
+};
+
+exports.error = function error (err) {
+    util.log([
+        "Terminated '",
+        util.colors.cyan(this.name),
+        "' with error: ",
+        util.colors.red(err)
     ].join(""));
 };

--- a/src/lib/promisify.js
+++ b/src/lib/promisify.js
@@ -18,7 +18,12 @@ var isPromise = function (thing) {
 
 module.exports = function promisify (fn) {
     return function promisifyWrapper (/* arguments */) {
-        var ret = fn();
+        var ret;
+        try {
+            ret = fn();
+        } catch (err) {
+            return BPromise.reject(err);
+        }
         if (isPromise(ret)) {
             return ret;
         }

--- a/src/pro-gulp.js
+++ b/src/pro-gulp.js
@@ -13,7 +13,8 @@ exports.task = function task (name, dependency, fn) {
                 .then(log.start)
                 .then(promisify(dependency))
                 .then(promisify(fn || function noop () {}))
-                .then(log.end);
+                .then(log.end)
+                .catch(log.error);
         };
     }
     return tasks[name];

--- a/test/lib/log.js
+++ b/test/lib/log.js
@@ -52,3 +52,20 @@ describe("The `log.end` function", function () {
 
 
 });
+
+describe("The `log.error` function", function () {
+
+    beforeEach(function () {
+        sinon.stub(util, "log");
+    });
+
+    afterEach(function () {
+        util.log.restore();
+    });
+
+    it("should call the `gulp-util.log` function", function () {
+        log.error.call({});
+        util.log.calledWithMatch(/Terminated/).should.equal(true);
+    });
+
+});

--- a/test/lib/promisify.js
+++ b/test/lib/promisify.js
@@ -90,20 +90,21 @@ describe("When the supplied function returns a value, the promise returned by th
             return value;
         });
         var ret = fn();
-        return ret.should.eventually.equal(value);
+        return ret.should.fulfilledWith(value);
     });
 
 });
 
 
-describe("When the supplied function throws, the wrapper", function () {
+describe("When the supplied function throws, the promise returned by the wrapper", function () {
 
-    it("should throw", function () {
+    it("should be a promise that is rejected with the thrown error", function () {
         var error = new Error();
         var fn = promisify(function () {
             throw error;
         });
-        fn.should.throw(error);
+        var ret = fn();
+        ret.should.rejectedWith(error);
     });
 
 });


### PR DESCRIPTION
This pull request fixes #1 catching exceptions thrown by the function being promisified and returning a rejected promise with the exception error.
Also, this adds a catch handler that logs the error in case a rejected promise is returned by a progulp task, in order to do not break the main gulp stream.
